### PR TITLE
Implement backend route stubs and utils

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/backend/routes/products.js
+++ b/backend/routes/products.js
@@ -1,0 +1,16 @@
+import express from 'express';
+
+const router = express.Router();
+
+// List products
+router.get('/', (req, res) => {
+  res.json({ message: 'List of products' });
+});
+
+// Create a new product
+router.post('/', (req, res) => {
+  const product = req.body;
+  res.status(201).json({ message: 'Product created', product });
+});
+
+export default router;

--- a/backend/routes/setting.js
+++ b/backend/routes/setting.js
@@ -1,0 +1,16 @@
+import express from 'express';
+
+const router = express.Router();
+
+// Get application settings
+router.get('/', (req, res) => {
+  res.json({ message: 'Get settings' });
+});
+
+// Update application settings
+router.post('/', (req, res) => {
+  const settings = req.body;
+  res.json({ message: 'Settings saved', settings });
+});
+
+export default router;

--- a/backend/routes/shipping.js
+++ b/backend/routes/shipping.js
@@ -1,0 +1,11 @@
+import express from 'express';
+
+const router = express.Router();
+
+// Generate a shipping quote
+router.post('/quote', (req, res) => {
+  const { from, to, weight } = req.body;
+  res.json({ message: 'Shipping quote', from, to, weight });
+});
+
+export default router;

--- a/backend/utils/mwsClient.js
+++ b/backend/utils/mwsClient.js
@@ -1,0 +1,10 @@
+// Simple placeholder for Amazon MWS client
+// In a real application this would call the Amazon Marketplace Web Services API
+
+export async function listOrders() {
+  return [];
+}
+
+export default {
+  listOrders,
+};

--- a/backend/utils/upsClient.js
+++ b/backend/utils/upsClient.js
@@ -1,0 +1,10 @@
+// Minimal UPS client placeholder
+// Replace with real API integration when credentials are available
+
+export async function getQuote(options) {
+  return { rate: 0, ...options };
+}
+
+export default {
+  getQuote,
+};


### PR DESCRIPTION
## Summary
- add simple `products`, `shipping`, and `setting` route handlers
- create placeholder `mwsClient` and `upsClient` utilities
- define a minimal Jest configuration

## Testing
- `npm run test-db` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68434892cb3c83249b5460301c5d785a