### PR TITLE
Add frontend auth and utilities

### DIFF
--- a/frontend/app/login/page.jsx
+++ b/frontend/app/login/page.jsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+import { auth } from "@/lib/firebase";
+import { signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80">
+        <h1 className="text-xl font-bold mb-4">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="border p-2 mb-2 w-full"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border p-2 mb-2 w-full"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded w-full">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/signup/page.jsx
+++ b/frontend/app/signup/page.jsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+import { auth } from "@/lib/firebase";
+import { createUserWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await createUserWithEmailAndPassword(auth, email, password);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80">
+        <h1 className="text-xl font-bold mb-4">Sign Up</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          className="border p-2 mb-2 w-full"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          className="border p-2 mb-2 w-full"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+        <button type="submit" className="bg-green-500 text-white px-4 py-2 rounded w-full">
+          Sign Up
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/components/DashboardLayout.jsx
+++ b/frontend/components/DashboardLayout.jsx
@@ -1,0 +1,21 @@
+"use client";
+import Link from "next/link";
+
+export default function DashboardLayout({ children }) {
+  return (
+    <div className="min-h-screen flex">
+      <aside className="w-48 bg-gray-800 text-white p-4 space-y-2">
+        <h2 className="text-lg font-bold mb-4">Dashboard</h2>
+        <nav className="space-y-1">
+          <Link href="/" className="block hover:underline">
+            Home
+          </Link>
+          <Link href="/products" className="block hover:underline">
+            Products
+          </Link>
+        </nav>
+      </aside>
+      <main className="flex-1 p-4 bg-gray-50">{children}</main>
+    </div>
+  );
+}

--- a/frontend/components/ProductCard.jsx
+++ b/frontend/components/ProductCard.jsx
@@ -1,0 +1,21 @@
+"use client";
+export default function ProductCard({ product, onAdd }) {
+  return (
+    <div className="border rounded shadow p-4 flex flex-col items-center">
+      {product.image && (
+        <img src={product.image} alt={product.name} className="h-32 w-32 object-cover mb-2" />
+      )}
+      <h2 className="font-semibold text-lg mb-1">{product.name}</h2>
+      <p className="text-gray-600 mb-2">{product.description}</p>
+      <p className="font-bold mb-2">${product.price}</p>
+      {onAdd && (
+        <button
+          onClick={() => onAdd(product)}
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+        >
+          Add to Cart
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/ShippingCalculator.jsx
+++ b/frontend/components/ShippingCalculator.jsx
@@ -1,0 +1,40 @@
+"use client";
+import { useState } from "react";
+
+export default function ShippingCalculator({ onCalculate }) {
+  const [weight, setWeight] = useState("");
+  const [destination, setDestination] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (onCalculate) {
+      onCalculate({ weight, destination });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 border rounded">
+      <div className="mb-2">
+        <label className="block text-sm mb-1">Weight (kg)</label>
+        <input
+          type="number"
+          value={weight}
+          onChange={(e) => setWeight(e.target.value)}
+          className="border p-2 w-full"
+        />
+      </div>
+      <div className="mb-2">
+        <label className="block text-sm mb-1">Destination</label>
+        <input
+          type="text"
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          className="border p-2 w-full"
+        />
+      </div>
+      <button type="submit" className="bg-green-500 text-white px-4 py-2 rounded">
+        Calculate
+      </button>
+    </form>
+  );
+}

--- a/frontend/lib/useAuth.ts
+++ b/frontend/lib/useAuth.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { onAuthStateChanged, User } from "https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js";
+import { auth } from "@/lib/firebase";
+
+export default function useAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return () => unsub();
+  }, []);
+
+  return { user, loading };
+}

--- a/frontend/lib/useFetchProducts.ts
+++ b/frontend/lib/useFetchProducts.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+export interface Product {
+  id: string;
+  name: string;
+  price: number;
+  description?: string;
+  image?: string;
+}
+
+export default function useFetchProducts() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchProducts() {
+      try {
+        const res = await fetch("/api/products");
+        const data = await res.json();
+        setProducts(data);
+      } catch (err) {
+        console.error("Failed to fetch products", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchProducts();
+  }, []);
+
+  return { products, loading };
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+// Minimal Firebase admin setup for verifying tokens
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getAuth } from "firebase-admin/auth";
+
+const app = initializeApp({ credential: applicationDefault() });
+
+export async function middleware(req: NextRequest) {
+  const token = req.cookies.get("token")?.value;
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+
+  try {
+    await getAuth(app).verifyIdToken(token);
+    return NextResponse.next();
+  } catch (err) {
+    console.error("Auth verification failed", err);
+    return NextResponse.redirect(new URL("/login", req.url));
+  }
+}
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/products/:path*"],
+};


### PR DESCRIPTION
## Summary
- create Login and Signup pages with Tailwind styling
- add reusable ProductCard and ShippingCalculator components
- implement DashboardLayout wrapper
- add useAuth and useFetchProducts hooks
- implement middleware to gate protected routes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843488ef3c483248fcba75c58b6585c